### PR TITLE
Review Comments: do not specificly type ActionCreators

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,4 @@
-import { configureStore, ActionCreator, Action } from 'redux-starter-kit'
+import { configureStore, Action } from 'redux-starter-kit'
 import { ThunkAction } from 'redux-thunk'
 
 import rootReducer, { RootState } from './rootReducer'
@@ -16,8 +16,6 @@ if (process.env.NODE_ENV === 'development' && module.hot) {
 
 export type AppDispatch = typeof store.dispatch
 
-export type AppThunk = ActionCreator<
-  ThunkAction<void, RootState, null, Action<string>>
->
+export type AppThunkAction = ThunkAction<void, RootState, null, Action<string>>
 
 export default store

--- a/src/features/issueDetails/commentsSlice.ts
+++ b/src/features/issueDetails/commentsSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from 'redux-starter-kit'
 
 import { Comment, getComments, Issue } from 'api/githubAPI'
-import { AppThunk } from 'app/store'
+import { AppThunkAction } from 'app/store';
 
 interface CommentsState {
   commentsByIssue: Record<number, Comment[] | undefined>
@@ -48,7 +48,7 @@ export const {
 } = comments.actions
 export default comments.reducer
 
-export const fetchComments: AppThunk = (issue: Issue) => async dispatch => {
+export const fetchComments = (issue: Issue): AppThunkAction => async dispatch => {
   try {
     dispatch(getCommentsStart())
     const comments = await getComments(issue.comments_url)

--- a/src/features/issuesList/issuesSlice.ts
+++ b/src/features/issuesList/issuesSlice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from 'redux-starter-kit'
 import { Links } from 'parse-link-header'
 
 import { Issue, IssuesResult, getIssue, getIssues } from 'api/githubAPI'
-import { AppThunk } from 'app/store'
+import { AppThunkAction } from 'app/store'
 
 interface IssuesState {
   issuesByNumber: Record<number, Issue>
@@ -72,11 +72,11 @@ export const {
 
 export default issues.reducer
 
-export const fetchIssues: AppThunk = (
+export const fetchIssues = (
   org: string,
   repo: string,
   page?: number
-) => async dispatch => {
+): AppThunkAction => async dispatch => {
   try {
     dispatch(getIssuesStart())
     const issues = await getIssues(org, repo, page)
@@ -86,11 +86,11 @@ export const fetchIssues: AppThunk = (
   }
 }
 
-export const fetchIssue: AppThunk = (
+export const fetchIssue = (
   org: string,
   repo: string,
   number: number
-) => async dispatch => {
+): AppThunkAction => async dispatch => {
   try {
     dispatch(getIssueStart())
     const issue = await getIssue(org, repo, number)

--- a/src/features/repoSearch/repoDetailsSlice.ts
+++ b/src/features/repoSearch/repoDetailsSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction } from 'redux-starter-kit'
 
-import { AppThunk } from 'app/store'
 
 import { RepoDetails, getRepoDetails } from 'api/githubAPI'
+import { AppThunkAction } from 'app/store';
 
 interface RepoDetailsState {
   openIssuesCount: number
@@ -36,10 +36,10 @@ export const {
 
 export default repoDetails.reducer
 
-export const fetchIssuesCount: AppThunk = (
+export const fetchIssuesCount = (
   org: string,
   repo: string
-) => async dispatch => {
+): AppThunkAction => async dispatch => {
   try {
     const repoDetails = await getRepoDetails(org, repo)
     dispatch(getRepoDetailsSuccess(repoDetails))


### PR DESCRIPTION
Heya,
I'm just skimming over the advanced tutorial and I noticed something:

You're specificly typing actionCreators as `ActionCreator<Foo>`.

This is something I would avoid teaching as it hides important type information.

Compare these two examples:

```typescript
export const fetchIssues: AppThunk = (
  org: string,
  repo: string,
  page?: number
) => async dispatch => {
  try {
    dispatch(getIssuesStart())
    const issues = await getIssues(org, repo, page)
    dispatch(getIssuesSuccess(issues))
  } catch (err) {
    dispatch(getIssuesFailure(err.toString()))
  }
}

export const fetchIssues2 = (
  org: string,
  repo: string,
  page?: number
): AppThunkAction => async dispatch => {
  try {
    dispatch(getIssuesStart())
    const issues = await getIssues(org, repo, page)
    dispatch(getIssuesSuccess(issues))
  } catch (err) {
    dispatch(getIssuesFailure(err.toString()))
  }
}
```

In these examples, `fetchIssues` has a signature like `(...args: any[]) => ThunkAction<...>` - `fetchIssues2` on the other hand has a signature like `(
  org: string,
  repo: string,
  page?: number
): ThunkAction<...>`

So, by being explicit with defining the AppThunk, you are actually erasing type information and make it possible to call `fetchIssues` with wrong (or none at all) arguments.

`fetchIssues2` on the other hand is not specificly _typed_ as an `ActionCreator`, but since it's a function that returns a `ThunkAction`, it's perfectly valid to be used in any place an `ActionCreator` could be used.